### PR TITLE
Fix shared view count increment and fetch error handling

### DIFF
--- a/app/shared/[token]/page.tsx
+++ b/app/shared/[token]/page.tsx
@@ -48,6 +48,7 @@ export default function SharedReportPage() {
           .select(`
             analysis_id,
             expires_at,
+            view_count,
             analyses (
               id,
               company_name,
@@ -74,7 +75,7 @@ export default function SharedReportPage() {
         // Increment view count
         await supabase
           .from("shared_reports")
-          .update({ view_count: supabase.raw("view_count + 1") })
+          .update({ view_count: (sharedData.view_count || 0) + 1 })
           .eq("share_token", params.token)
 
         setAnalysisData(sharedData.analyses as SharedAnalysisData)


### PR DESCRIPTION
## Summary
- increment shared report view count without using `.raw`
- handle fetch timeouts using `AbortController`
- guard against unknown error types in API route
- allow using gpt-4o model via type cast

## Testing
- `npx tsc --noEmit` *(fails: Property 'raw' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6869a28e44648325ad119981e0133ca7